### PR TITLE
Install wget to avoid the busybox wget leaking defunct processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.19
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates wget
 
 RUN set -eux; \
 # https://github.com/distribution/distribution/releases


### PR DESCRIPTION
When running busybox wget v1.31.x to request an SSL page, there is a leak of defunct processes that eventually could hit the limit for fork syscalls, leading to the unavailability of main registry process.

Installing wget from the alpine repository resolves the issue as this only affects the busybox distribution. Moreover, this should transparently resolve the issue for deployments
using wget as healthcheck/readiness/liveness probe.

xref: https://bugs.busybox.net/show_bug.cgi?id=15967

Closes #158